### PR TITLE
Add context menu "Translate" command for message translation

### DIFF
--- a/bot/commands/context-translate.js
+++ b/bot/commands/context-translate.js
@@ -1,0 +1,78 @@
+// commands/context-translate.js - Context menu "Translate" message command
+const {
+  ContextMenuCommandBuilder,
+  ApplicationCommandType,
+  ApplicationIntegrationType,
+  InteractionContextType,
+  ActionRowBuilder,
+  StringSelectMenuBuilder,
+  EmbedBuilder,
+} = require("discord.js");
+
+// Language choices for the select menu
+const LANGUAGE_OPTIONS = [
+  { label: "English", value: "en", emoji: "🇺🇸" },
+  { label: "Spanish", value: "es", emoji: "🇪🇸" },
+  { label: "French", value: "fr", emoji: "🇫🇷" },
+  { label: "German", value: "de", emoji: "🇩🇪" },
+  { label: "Italian", value: "it", emoji: "🇮🇹" },
+  { label: "Portuguese", value: "pt", emoji: "🇵🇹" },
+  { label: "Japanese", value: "ja", emoji: "🇯🇵" },
+  { label: "Korean", value: "ko", emoji: "🇰🇷" },
+  { label: "Chinese", value: "zh", emoji: "🇨🇳" },
+  { label: "Russian", value: "ru", emoji: "🇷🇺" },
+  { label: "Arabic", value: "ar", emoji: "🇸🇦" },
+  { label: "Hindi", value: "hi", emoji: "🇮🇳" },
+  { label: "Turkish", value: "tr", emoji: "🇹🇷" },
+  { label: "Dutch", value: "nl", emoji: "🇳🇱" },
+  { label: "Swedish", value: "sv", emoji: "🇸🇪" },
+  { label: "Norwegian", value: "no", emoji: "🇳🇴" },
+  { label: "Danish", value: "da", emoji: "🇩🇰" },
+  { label: "Finnish", value: "fi", emoji: "🇫🇮" },
+  { label: "Polish", value: "pl", emoji: "🇵🇱" },
+  { label: "Czech", value: "cs", emoji: "🇨🇿" },
+  { label: "Hungarian", value: "hu", emoji: "🇭🇺" },
+  { label: "Greek", value: "el", emoji: "🇬🇷" },
+  { label: "Thai", value: "th", emoji: "🇹🇭" },
+  { label: "Vietnamese", value: "vi", emoji: "🇻🇳" },
+  { label: "Indonesian", value: "id", emoji: "🇮🇩" },
+];
+
+module.exports = {
+  data: new ContextMenuCommandBuilder()
+    .setName("Translate")
+    .setType(ApplicationCommandType.Message)
+    .setIntegrationTypes([
+      ApplicationIntegrationType.GuildInstall,
+      ApplicationIntegrationType.UserInstall,
+    ])
+    .setContexts([
+      InteractionContextType.Guild,
+      InteractionContextType.BotDM,
+      InteractionContextType.PrivateChannel,
+    ]),
+
+  async execute(interaction) {
+    const targetMessage = interaction.targetMessage;
+
+    if (!targetMessage.content || targetMessage.content.trim().length === 0) {
+      return interaction.reply({
+        content: "That message has no text content to translate.",
+        flags: 64,
+      });
+    }
+
+    const row = new ActionRowBuilder().addComponents(
+      new StringSelectMenuBuilder()
+        .setCustomId(`ctx_translate:${targetMessage.id}`)
+        .setPlaceholder("Select a language to translate to...")
+        .addOptions(LANGUAGE_OPTIONS)
+    );
+
+    await interaction.reply({
+      content: "Select a language to translate this message into:",
+      components: [row],
+      flags: 64,
+    });
+  },
+};

--- a/bot/handlers/interactionHandler.js
+++ b/bot/handlers/interactionHandler.js
@@ -1,9 +1,11 @@
-// handlers/interactionHandler.js (Updated to handle editing)
+// handlers/interactionHandler.js (Updated to handle editing + context menu translate)
 const ReactionRoleButtons = require('./reactionRoleButtons');
+const { EmbedBuilder } = require('discord.js');
 
 class InteractionHandler {
-  constructor(storageService) {
+  constructor(storageService, translationService) {
     this.storageService = storageService;
+    this.translationService = translationService;
     this.reactionRoleButtons = new ReactionRoleButtons(storageService);
   }
 
@@ -14,6 +16,11 @@ class InteractionHandler {
       }
 
       if (interaction.isStringSelectMenu()) {
+        // Handle context menu translation language selection
+        if (interaction.customId.startsWith('ctx_translate:')) {
+          return await this.handleContextTranslate(interaction);
+        }
+
         // Handle edit reaction role selection
         if (interaction.customId === 'edit_rr_select') {
           return await this.handleEditRRSelection(interaction);
@@ -41,6 +48,78 @@ class InteractionHandler {
     }
 
     return false;
+  }
+
+  async handleContextTranslate(interaction) {
+    const messageId = interaction.customId.split(':')[1];
+    const targetLang = interaction.values[0];
+
+    await interaction.deferUpdate();
+
+    try {
+      // Fetch the original message from the channel
+      const message = await interaction.channel.messages.fetch(messageId);
+
+      if (!message || !message.content || message.content.trim().length === 0) {
+        await interaction.editReply({
+          content: 'Could not find that message or it has no text content.',
+          components: [],
+        });
+        return true;
+      }
+
+      const translatedText = await this.translationService.translateMessage(
+        message.content,
+        targetLang,
+        {
+          discordUserId: interaction.user.id,
+          userName: interaction.user.username,
+          guildId: interaction.guildId,
+          channelId: interaction.channelId,
+          guildName: interaction.guild?.name,
+          channelName: interaction.channel?.name,
+        }
+      );
+
+      if (!translatedText) {
+        await interaction.editReply({
+          content: 'Translation returned no result. The message may already be in the target language.',
+          components: [],
+        });
+        return true;
+      }
+
+      const langNames = {
+        en: 'English', es: 'Spanish', fr: 'French', de: 'German', it: 'Italian',
+        pt: 'Portuguese', ja: 'Japanese', ko: 'Korean', zh: 'Chinese', ru: 'Russian',
+        ar: 'Arabic', hi: 'Hindi', tr: 'Turkish', nl: 'Dutch', sv: 'Swedish',
+        no: 'Norwegian', da: 'Danish', fi: 'Finnish', pl: 'Polish', cs: 'Czech',
+        hu: 'Hungarian', el: 'Greek', th: 'Thai', vi: 'Vietnamese', id: 'Indonesian',
+      };
+
+      const embed = new EmbedBuilder()
+        .setColor('#50fa7b')
+        .setAuthor({ name: `Translated to ${langNames[targetLang] || targetLang.toUpperCase()}` })
+        .setDescription(translatedText)
+        .setFooter({
+          text: `Requested by ${interaction.user.username}`,
+          iconURL: interaction.user.displayAvatarURL({ extension: 'png' }),
+        });
+
+      await interaction.editReply({
+        content: null,
+        embeds: [embed],
+        components: [],
+      });
+    } catch (err) {
+      console.error('Context menu translation failed:', err);
+      await interaction.editReply({
+        content: `Translation failed: ${err.message}`,
+        components: [],
+      });
+    }
+
+    return true;
   }
 
   async handleEditRRSelection(interaction) {

--- a/bot/index.js
+++ b/bot/index.js
@@ -52,7 +52,7 @@ const messageHandler = new MessageHandler(storageService, config);
 const reactionHandler = new ReactionHandler(storageService, translationService, config);
 const reactionRoleHandler = new ReactionRoleHandler(storageService, client);
 const reactionProtectionHandler = new ReactionProtectionHandler(storageService, client);
-const interactionHandler = new InteractionHandler(storageService);
+const interactionHandler = new InteractionHandler(storageService, translationService);
 const autoTranslateHandler = new AutoTranslateHandler(storageService, translationService, client);
 const userEventHandler = new UserEventHandler(storageService, config);
 const serverEventHandler = new ServerEventHandler(storageService, config);
@@ -241,6 +241,17 @@ client.on("interactionCreate", async (interaction) => {
     // Handle button/modal/select menu interactions first
     const handledByInteractionHandler = await interactionHandler.handleInteraction(interaction);
     if (handledByInteractionHandler) return;
+
+    // Handle context menu commands (message commands like "Translate")
+    if (interaction.isMessageContextMenuCommand()) {
+      const command = commands.get(interaction.commandName);
+      if (!command) {
+        console.error(`Context menu command not found: ${interaction.commandName}`);
+        return;
+      }
+      await command.execute(interaction);
+      return;
+    }
 
     // Handle slash commands
     if (interaction.isChatInputCommand()) {


### PR DESCRIPTION
## Summary
This PR adds a new context menu command that allows users to right-click on any message and translate it to their chosen language. The feature integrates with the existing translation service and provides a user-friendly language selection interface.

## Key Changes
- **New Context Menu Command** (`bot/commands/context-translate.js`): Added a message context menu command named "Translate" that displays a language selection dropdown with 25 supported languages, each with corresponding flag emojis
- **Interaction Handler Enhancement** (`bot/handlers/interactionHandler.js`):
  - Updated constructor to accept `translationService` dependency
  - Added `handleContextTranslate()` method to process language selection and perform message translation
  - Integrated context menu translation handling into the interaction routing logic
  - Generates formatted embed responses with translated text, language name, and requester information
- **Main Bot File** (`bot/index.js`):
  - Passed `translationService` to `InteractionHandler` constructor
  - Added dedicated handler for context menu commands in the interaction event listener

## Implementation Details
- The context menu command is available in guilds, bot DMs, and private channels
- Language selection uses a string select menu with custom ID format `ctx_translate:{messageId}`
- Translation results are displayed in a green embed with the target language name in the author field
- Error handling includes checks for empty messages and translation failures
- The feature respects Discord's ephemeral message flag (64) for the initial language selection prompt
- Comprehensive context metadata (user ID, guild name, channel name, etc.) is passed to the translation service for logging/analytics purposes

https://claude.ai/code/session_017MQoWqrH1qq9si1XvNzg9b